### PR TITLE
Refactor get schema file as a resource method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
             <dependency>
                 <groupId>com.graphql-java</groupId>
                 <artifactId>graphql-java</artifactId>
-                <version>7.0</version>
+                <version>8.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Some additional fixes related to the https://github.com/smoketurner/dropwizard-graphql/issues/4
Changes:
* Refactor get schema file as a resource,
* Delete unnecessary exception
* Update graphql-java to 8.0